### PR TITLE
added ability to look up weather by city id

### DIFF
--- a/pxl999/Watchy_Base.cpp
+++ b/pxl999/Watchy_Base.cpp
@@ -231,8 +231,11 @@ weatherData WatchyBase::getWeather(){
         if(!runOnce && connectWiFi()){//Use Weather API for live data if WiFi is connected
             HTTPClient http;
             http.setConnectTimeout(3000);//3 second max timeout
-            String weatherQueryURL = String(URL) + String(CITY) + String(",") + String(COUNTRY) + String("&units=") + String(TEMP) + String("&appid=") + String(APIKEY);
-            http.begin(weatherQueryURL.c_str());
+#ifdef CITY_ID
+            String weatherQueryURL = String(URL) + String("?id=")+ String(CITY_ID) + String("&units=") + String(TEMP) + String("&appid=") + String(APIKEY);
+#else            
+            String weatherQueryURL = String(URL) + String("?q=") + String(CITY) + String(",") + String(COUNTRY) + String("&units=") + String(TEMP) + String("&appid=") + String(APIKEY);
+#endif            http.begin(weatherQueryURL.c_str());
             int httpResponseCode = http.GET();
             if(httpResponseCode == 200) {
                 String payload = http.getString();

--- a/pxl999/Watchy_Base.h
+++ b/pxl999/Watchy_Base.h
@@ -16,6 +16,7 @@ extern RTC_DATA_ATTR bool debugger;
 
 //weather api - Update these to match your city/country/api key
 //get your free api key from: https://openweathermap.org/appid
+//#define CITY_ID "5378538" // if your city name isn't very unique, you can use its ID instead
 #define CITY "WADING+RIVER" //if your city name has a space, replace with '+'
 #define COUNTRY "US"
 #define APIKEY "f058fe1cad2afe8e2ddc5d063a64cecb" //use your own API key (this is SQFMI'S) :)


### PR DESCRIPTION
It turns out there's a couple Oaklands in the US, so I added the ability to fetch weather by OpenWeatherMap's city ID instead of city and country code. When you look up a city on their site, it'll take you to a page like "https://openweathermap.org/city/4574324" - copy those digits on the end and put them into CITY_ID in Watchy_Base.h.